### PR TITLE
fix: requires for bundlers

### DIFF
--- a/lib/bunyan.js
+++ b/lib/bunyan.js
@@ -78,7 +78,7 @@ if (runtimeEnv === 'browser') {
     
     if (process.env.BUNYAN_DTRACE) {
         try {
-            dtrace = require('dtrace-provider' + '');
+            dtrace = require('dtrace-provider');
         } catch (e) {
             dtrace = null;
         }
@@ -102,13 +102,13 @@ if (process.env.BUNYAN_TEST_NO_SAFE_JSON_STRINGIFY) {
 
 // The 'mv' module is required for rotating-file stream support.
 try {
-    var mv = require('mv' + '');
+    var mv = require('mv');
 } catch (e) {
     mv = null;
 }
 
 try {
-    var sourceMapSupport = require('source-map-support' + '');
+    var sourceMapSupport = require('source-map-support');
 } catch (_) {
     sourceMapSupport = null;
 }


### PR DESCRIPTION
The + '' sytax means bundlers such as rollup using
commonjs to convert to es6 can not correctly include these in the bundle.

Which leads to a run time failure.
Most bundlers provide a way to ignore these for browsers such as exclude etc.